### PR TITLE
Standardize GitHub project workflows

### DIFF
--- a/.github/linters/trivy.yaml
+++ b/.github/linters/trivy.yaml
@@ -1,0 +1,15 @@
+---
+# Mirrors the super-linter default configuration, with one change: remote
+# dependency resolution is disabled. Trivy's Maven analyzer downloads parent
+# pom files from Maven Central, which rate-limits GitHub Actions runners
+# (HTTP 429, Retry-After: 1800) and fails this job. Offline mode keeps all
+# three scanners enabled without the network lookups.
+exit-code: 1
+exit-on-eol: 2
+scan:
+  disable-telemetry: true
+  offline: true
+  scanners:
+    - vuln
+    - misconfig
+    - secret

--- a/.github/linters/zizmor.yaml
+++ b/.github/linters/zizmor.yaml
@@ -2,4 +2,7 @@ rules:
   unpinned-uses:
     config:
       policies:
-        "*": ref-pin
+        # Third-party actions MUST be pinned to a full commit SHA (immutable).
+        "*": hash-pin
+        # First-party reusables are consumed at the moving major tag by design.
+        "senzing-factory/*": ref-pin

--- a/.github/workflows/add-labels-standardized.yaml
+++ b/.github/workflows/add-labels-standardized.yaml
@@ -1,4 +1,4 @@
-name: add labels standardized
+name: Add labels standardized
 
 on:
   issues:

--- a/.github/workflows/add-to-project-senzing-dependabot.yaml
+++ b/.github/workflows/add-to-project-senzing-dependabot.yaml
@@ -1,4 +1,4 @@
-name: add to project senzing github organization dependabot
+name: Add to project senzing github organization dependabot
 
 on:
   pull_request:

--- a/.github/workflows/add-to-project-senzing-dependabot.yaml
+++ b/.github/workflows/add-to-project-senzing-dependabot.yaml
@@ -11,17 +11,10 @@ jobs:
     permissions:
       repository-projects: write
     secrets:
-      PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
+      APP_CLIENT_ID: ${{ secrets.SENZING_GITHUB_PROJECT_APP_CLIENT_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.SENZING_GITHUB_PROJECT_APP_PRIVATE_KEY }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     uses: senzing-factory/build-resources/.github/workflows/add-to-project-dependabot.yaml@v4
     with:
       project: ${{ vars.SENZING_GITHUB_ORGANIZATION_PROJECT }}
-
-  slack-notification:
-    needs: [add-to-project-dependabot]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-to-project-dependabot.result) }}
-    secrets:
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
-    with:
-      job-status: ${{ needs.add-to-project-dependabot.result }}

--- a/.github/workflows/add-to-project-senzing.yaml
+++ b/.github/workflows/add-to-project-senzing.yaml
@@ -1,4 +1,4 @@
-name: add to project senzing github organization
+name: Add to project senzing github organization
 
 on:
   issues:

--- a/.github/workflows/add-to-project-senzing.yaml
+++ b/.github/workflows/add-to-project-senzing.yaml
@@ -13,18 +13,11 @@ jobs:
     permissions:
       repository-projects: write
     secrets:
-      PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
+      APP_CLIENT_ID: ${{ secrets.SENZING_GITHUB_PROJECT_APP_CLIENT_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.SENZING_GITHUB_PROJECT_APP_PRIVATE_KEY }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     uses: senzing-factory/build-resources/.github/workflows/add-to-project.yaml@v4
     with:
       project-number: ${{ vars.SENZING_GITHUB_ORGANIZATION_PROJECT }}
       org: ${{ vars.SENZING_GITHUB_ACCOUNT_NAME }}
-
-  slack-notification:
-    needs: [add-to-project]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.add-to-project.result) }}
-    secrets:
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
-    uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
-    with:
-      job-status: ${{ needs.add-to-project.result }}

--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -1,12 +1,12 @@
 name: Claude PR Review
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
-
 on:
   pull_request:
     types: [opened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 permissions: {}
 

--- a/.github/workflows/dependabot-approve-and-merge.yaml
+++ b/.github/workflows/dependabot-approve-and-merge.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -1,10 +1,12 @@
-name: lint workflows
+name: Lint workflows
 
 on:
-  push:
-    branches-ignore: [main]
   pull_request:
     branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 permissions: {}
 

--- a/.github/workflows/move-pr-to-done-dependabot.yaml
+++ b/.github/workflows/move-pr-to-done-dependabot.yaml
@@ -1,4 +1,4 @@
-name: move pr to done dependabot
+name: Move pr to done dependabot
 
 on:
   pull_request:

--- a/.github/workflows/move-pr-to-done-dependabot.yaml
+++ b/.github/workflows/move-pr-to-done-dependabot.yaml
@@ -12,7 +12,8 @@ jobs:
     permissions:
       repository-projects: write
     secrets:
-      PROJECT_RW_TOKEN: ${{ secrets.SENZING_GITHUB_PROJECT_RW_TOKEN }}
+      APP_CLIENT_ID: ${{ secrets.SENZING_GITHUB_PROJECT_APP_CLIENT_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.SENZING_GITHUB_PROJECT_APP_PRIVATE_KEY }}
     uses: senzing-factory/build-resources/.github/workflows/move-pr-to-done-dependabot.yaml@v4
     with:
       project: ${{ vars.SENZING_GITHUB_ORGANIZATION_PROJECT }}

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -1,8 +1,12 @@
-name: spellcheck
+name: Spellcheck
 
 on:
   pull_request:
     branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 permissions: {}
 

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -25,6 +25,7 @@
     "LICENSESTRINGBASE",
     "lucene",
     "RESOURCEPATH",
+    "reusables",
     "Senzing",
     "senzingapi",
     "sslmode",

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -24,6 +24,8 @@
     "kernelsam",
     "LICENSESTRINGBASE",
     "lucene",
+    "misconfig",
+    "pom",
     "RESOURCEPATH",
     "reusables",
     "Senzing",
@@ -32,6 +34,8 @@
     "stackoverflow",
     "Stringifier",
     "SUPPORTPATH",
+    "trivy",
+    "vuln",
     "WATCHLIST"
   ],
   "ignorePaths": [


### PR DESCRIPTION
Switch add-to-project*/move-pr-to-done to the GitHub App, hash-pin zizmor,
and sync the standard default workflow set + supporting infra.
